### PR TITLE
nitpick: Remove duplicate 'application/x-bzip2' from mime types

### DIFF
--- a/lib/mime_types.ex
+++ b/lib/mime_types.ex
@@ -96,7 +96,6 @@ defmodule Bonfire.Files.MimeTypes do
       "application/zip" => ["zip"],
       "application/vnd.rar" => ["rar"],
       "application/x-7z-compressed" => ["7z"],
-      "application/x-bzip2" => ["bzip2"],
 
       # code
       "text/swiftui" => ["swiftui"],


### PR DESCRIPTION
Saw this warning during `just setup-prod`

```
    warning: key "application/x-bzip2" will be overridden in map
    │
 88 │     do: %{
    │     ~~~~~~
    │
    └─ deps/bonfire_files/lib/mime_types.ex:88
```